### PR TITLE
Added a simplifying function using double ended deque that can run in linear time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.txt
 *.pt
 ac_solver/agents/checkpoints/
+*.pyc

--- a/ac_solver/agents/utils.py
+++ b/ac_solver/agents/utils.py
@@ -25,9 +25,7 @@ def load_initial_states_from_text_file(states_type):
 
     file_name_prefix = "greedy_solved" if states_type == "solved" else "all"
     file_name = f"{file_name_prefix}_presentations.txt"
-    with resources.open_text(
-        "ac_solver.search.miller_schupp.data", file_name
-    ) as file:
+    with resources.open_text("ac_solver.search.miller_schupp.data", file_name) as file:
         initial_states = [literal_eval(line.strip()) for line in file]
 
     print(f"Loaded {len(initial_states)} presentations from {file_name}.")

--- a/ac_solver/envs/ac_moves.py
+++ b/ac_solver/envs/ac_moves.py
@@ -184,7 +184,6 @@ def ACMove(move_id, presentation, max_relator_length, lengths, cyclical=True):
     lengths: A list of lengths of words in the presentation.
     cyclical: A bool; whether to cyclically reduce words in the resultant presentation or not.
     """
-
     assert move_id in range(
         0, 12
     ), f"Expect n to be in range 0-11 (both inclusive); got {move_id}"

--- a/tests/envs/test_envs_utils.py
+++ b/tests/envs/test_envs_utils.py
@@ -1,5 +1,9 @@
 import numpy as np
-from ac_solver.envs.utils import convert_relators_to_presentation
+
+from ac_solver.envs.utils import (
+    convert_relators_to_presentation,
+    simplify_relator_with_deque,
+)
 
 
 # Test convert_relators_to_presentation function
@@ -12,3 +16,56 @@ def test_convert_relators_to_presentation():
         [1, 1, -2, -2, -2, 0, 0, 1, 2, 1, -2, -1, -2, 0], dtype=np.int8
     )
     assert np.array_equal(arr, expected_array)
+
+
+def test_simplify_deque():
+    rel1 = np.array([1, 1, -2, -2, -2, 0, 0], dtype=np.int8)  # This cannot be reduced
+    rel2 = np.array(
+        [1, 1, 2, -2, -2, 0, 0], dtype=np.int8
+    )  # The middle 2s can be reduced
+    rel3 = np.array(
+        [1, 1, 2, -1, 1, -2, -2, 0, 0], dtype=np.int8
+    )  # The middle 1's and 2's can be reduced
+    rel4 = np.array(
+        [2, 1, -2, -2, -2, 0, 0], dtype=np.int8
+    )  # The head 2 can be reduced
+    rel5 = np.array(
+        [2, 1, 2, -2, -2, 0, 0], dtype=np.int8
+    )  # The head and middle 2's can be reduced
+    max_relator_length = 10
+    arr1, _ = simplify_relator_with_deque(
+        rel1, max_relator_length, cyclical=True, padded=True
+    )
+    arr2, _ = simplify_relator_with_deque(
+        rel2, max_relator_length, cyclical=True, padded=True
+    )
+    arr3, _ = simplify_relator_with_deque(
+        rel3, max_relator_length, cyclical=False, padded=True
+    )
+    arr4, _ = simplify_relator_with_deque(
+        rel4, max_relator_length, cyclical=True, padded=True
+    )
+    arr5, _ = simplify_relator_with_deque(
+        rel5, max_relator_length, cyclical=True, padded=False
+    )
+    arr6, _ = simplify_relator_with_deque(
+        rel5, max_relator_length, cyclical=False, padded=False
+    )
+
+    expected_array1 = np.array([1, 1, -2, -2, -2, 0, 0, 0, 0, 0], dtype=np.int8)
+    expected_array2 = np.array([1, 1, -2, 0, 0, 0, 0, 0, 0, 0], dtype=np.int8)
+    expected_array3 = np.array([1, 1, -2, 0, 0, 0, 0, 0, 0, 0], dtype=np.int8)
+    expected_array4 = np.array([1, -2, -2, 0, 0, 0, 0, 0, 0, 0], dtype=np.int8)
+    expected_array5 = np.array([1, 0, 0, 0, 0, 0, 0], dtype=np.int8)
+    expected_array6 = np.array([2, 1, -2, 0, 0, 0, 0], dtype=np.int8)
+    assert (
+        np.array_equal(arr1, expected_array1)
+        and np.array_equal(arr2, expected_array2)
+        and np.array_equal(arr3, expected_array3)
+        and np.array_equal(arr4, expected_array4)
+        and np.array_equal(arr5, expected_array5)
+        and np.array_equal(arr6, expected_array6)
+    )
+
+
+test_simplify_deque()


### PR DESCRIPTION
This pull request introduces a new `simplify_relator_with_deque` function utilizing a deque-based approach for relator simplification. The implementation achieves inverse pair elimination in O(n) time complexity and provides robust handling of cyclical eliminations.  This function also returns the count of non-zero elements in the simplified relator, serving as an invariant for the simplification process.

A comprehensive unit test `test_simplify_deque` is also provided.