### PR TITLE
Initialize ACEnv.supermoves to fix the checkpoint-save crash

### DIFF
--- a/ac_solver/envs/ac_env.py
+++ b/ac_solver/envs/ac_env.py
@@ -91,6 +91,7 @@ class ACEnv(Env):
             for i in range(self.n_gen)
         ]  # lengths of relators in the current state
         self.actions = []  # list of actions from the initial state
+        self.supermoves = None  # dict of supermoves when implemented; None for now
 
     def step(self, action):
         self.actions += [action]


### PR DESCRIPTION
Fixes #6.

`ACEnv.__init__` stopped initializing `self.supermoves` when the supermoves implementation was removed from the environment in 89b44fa, while the checkpoint-saving code in `training.py` still reads `envs.envs[0].supermoves` — so any run reaching update 100 crashes with an `AttributeError` at the first checkpoint save. See #6 for the full analysis and a minimal reproduction.

This restores the pre-refactor `self.supermoves = None` initialization. Since the attribute is not read anywhere in `step`/`reset`, it only affects checkpoint metadata, not training dynamics.

Verified on this branch, per `Contributions.md`:

- `pytest`: 112 passed
- `black --check` on the changed file: unchanged
- the reproduction from #6 (`python ac_solver/agents/ppo.py --num-envs 4 --num-steps 25 --total-timesteps 10000`) now completes with exit code 0 and writes `ckpt.pt`; a longer run (`--num-envs 64`, otherwise default settings) passed update 100, saved its checkpoint, and kept training normally past update 112

Happy to also add a fast checkpoint-path smoke test to `tests/` if you'd like it in this PR.
